### PR TITLE
chore: Simplified Github Build workflow and corrected README badge link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,4 @@
-name: Build Project
-
+name: Build
 on:
   push:
     branches: [ main, development ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Reusable Angular components built with Angular Material and Bootstrap 5.x, Utili
 
 <p align="center">
 
-[![CI](https://github.com/ngxsmart/ngxsmart/actions/workflows/cicd.yml/badge.svg)](https://github.com/ngxsmart/ngxsmart/actions/workflows/cicd.yml)
+[![CI](https://github.com/ngxsmart/ngxsmart/actions/workflows/build.yml/badge.svg)](https://github.com/ngxsmart/ngxsmart/actions/workflows/build.yml)
 <a href="https://www.npmjs.com/@js-smart/ngxsmart">
 <img src="https://img.shields.io/npm/v/@js-smart/ngxsmart" alt="Ngx Cookie Service on npm" />
 </a>


### PR DESCRIPTION
This commit contains two changes primarily. In the Github workflow file build.yml, the 'Build Project' name is simplified to 'Build'. The change is made to clean up and streamline the indicator names in our CI/CD pipeline. Secondly, in the README.md, the image URL for the CI badge is updated to point towards the new 'Build' workflow. The link previously pointed to a non-existent 'cicd.yml' file and this correction ensures users see the correct build status when visiting the project on Github.